### PR TITLE
Remove duplicate empty Menus tab in SiteConfig

### DIFF
--- a/src/SortableMenuManageExtension.php
+++ b/src/SortableMenuManageExtension.php
@@ -45,7 +45,7 @@ class SortableMenuManageExtension extends Extension
         if ($basePageClass !== '') {
             // Setup fields
             $rootTabSet = $fields->fieldByName('Root');
-            $sortableMenuTab = $rootTabSet->fieldByName('SortableMenu');
+            $sortableMenuTab = $rootTabSet->fieldByName(SortableMenuExtension::class);
             if (!$sortableMenuTab) {
                 $sortableMenuTab = TabSet::create(SortableMenuExtension::class, 'Menus');
                 $rootTabSet->push($sortableMenuTab);
@@ -54,7 +54,6 @@ class SortableMenuManageExtension extends Extension
             if (!$sortableMenuTab instanceof TabSet) {
                 throw new SortableMenuException('Sortable Menu must be a "TabSet", not "'.get_class($sortableMenuTab).'"');
             }
-            $sortableMenuTab = $fields->findOrMakeTab('Root.SortableMenu', 'Menus');
             $menus = singleton(SortableMenuExtension::class)->getSortableMenuConfiguration();
             foreach ($menus as $fieldName => $extraInfo) {
                 $fieldTitle = $extraInfo['Title'];


### PR DESCRIPTION
This PR is a patch for SS4. Due to the namespace, the Menus tab shows twice in the siteconfig page.
One of the tab is also empty since the code was injecting fields only in one of the 2.